### PR TITLE
Close the file resource when data is loaded

### DIFF
--- a/src/Zend/Translate/Adapter/Csv.php
+++ b/src/Zend/Translate/Adapter/Csv.php
@@ -103,6 +103,8 @@ class Zend_Translate_Adapter_Csv extends Zend_Translate_Adapter
             }
         }
 
+        fclose($this->_file);
+
         return $this->_data;
     }
 


### PR DESCRIPTION
When CSV transation file has finished loading, the file pointer remains open, which causes issues in high traffic environments. 

This PR fixes that by closing the pointer when data is loaded. 